### PR TITLE
1.2v 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Job Search API client
+
+## Usage
+```
+node index <job_types_list_filename.json> <key_list_filename.json>
+```


### PR DESCRIPTION
doesn't use job record id as _id of mongodb. _id is calculated using sha512 with job.title, job.company and job.location